### PR TITLE
Add hard-to-canonicalise name

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -38,7 +38,8 @@
 		"NULL",
 		"GoVeg.com",
 		"田中太郎",
-		"Leone Sextus Denys Oswolf Fraudatifilius Tollemache-Tollemache de Orellana Plantagenet Tollemache-Tollemache"
+		"Leone Sextus Denys Oswolf Fraudatifilius Tollemache-Tollemache de Orellana Plantagenet Tollemache-Tollemache",
+		"ᴮᴵᴳᴮᴵᴿᴰ"
 	],
 	"E-mail addresses": {
 		"Valid" :{ 


### PR DESCRIPTION
This caused a real-world bug as documented at https://labs.spotify.com/2013/06/18/creative-usernames/