### PR TITLE
Adding Gaelic example to names list

### DIFF
--- a/template/common/config.json
+++ b/template/common/config.json
@@ -43,7 +43,7 @@
 		"GoVeg.com",
 		"田中太郎",
 		"Leone Sextus Denys Oswolf Fraudatifilius Tollemache-Tollemache de Orellana Plantagenet Tollemache-Tollemache",
-		"ᴮᴵᴳᴮᴵᴿᴰ"
+		"ᴮᴵᴳᴮᴵᴿᴰ",
 		"Alasdair Mór Ùisdean GillEasbaig 'ic Iain Mac a' Ghobhainn Fear an t-Srònaich"
 	],
 	"E-mail addresses": {

--- a/template/common/config.json
+++ b/template/common/config.json
@@ -44,6 +44,7 @@
 		"田中太郎",
 		"Leone Sextus Denys Oswolf Fraudatifilius Tollemache-Tollemache de Orellana Plantagenet Tollemache-Tollemache",
 		"ᴮᴵᴳᴮᴵᴿᴰ"
+		"Alasdair Mór Ùisdean GillEasbaig 'ic Iain Mac a' Ghobhainn Fear an t-Srònaich"
 	],
 	"E-mail addresses": {
 		"Valid" :{ 


### PR DESCRIPTION
Some people with Gaelic names have issues completing online forms as their names are mistakenly treated as invalid.  This example has been checked and contains all the common issues.
